### PR TITLE
Potential fix for code scanning alert no. 1: Server-side request forgery

### DIFF
--- a/middleware.ts
+++ b/middleware.ts
@@ -6,6 +6,10 @@ export async function middleware(request: NextRequest) {
   if (request.nextUrl.pathname === "/dashboard" && !request.cookies.get("setup_complete")) {
     try {
       // Run auto-setup
+      const trustedOrigins = ["https://example.com"]; // Define trusted origins
+      if (!trustedOrigins.includes(request.nextUrl.origin)) {
+        throw new Error("Untrusted origin detected");
+      }
       const setupResponse = await fetch(`${request.nextUrl.origin}/api/auto-setup`, {
         method: "POST",
       })


### PR DESCRIPTION
Potential fix for [https://github.com/caranbradshaw/Dayta-Tech/security/code-scanning/1](https://github.com/caranbradshaw/Dayta-Tech/security/code-scanning/1)

To fix the issue, we need to ensure that the URL used in the `fetch` call is not directly constructed from user-controlled input. This can be achieved by validating or restricting the `request.nextUrl.origin` value against a predefined allow-list of trusted origins. If the origin is not in the allow-list, the request should be rejected or handled safely.

**Steps to fix:**
1. Define an allow-list of trusted origins that the server can safely use for outgoing requests.
2. Validate `request.nextUrl.origin` against this allow-list before constructing the URL.
3. If the origin is not in the allow-list, either reject the request or use a default safe origin.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
